### PR TITLE
chore: Configure CLion environment for Nix

### DIFF
--- a/.nix/g++
+++ b/.nix/g++
@@ -1,0 +1,1 @@
+../.nix/nix-run.sh

--- a/.nix/gcc
+++ b/.nix/gcc
@@ -1,0 +1,1 @@
+../.nix/nix-run.sh

--- a/.nix/make
+++ b/.nix/make
@@ -1,0 +1,1 @@
+../.nix/nix-run.sh

--- a/.nix/nix-cmake.sh
+++ b/.nix/nix-cmake.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+# Use the cmakeFlags set by Nix - this doesn't work with --build
+FLAGS=$(echo "$@" | grep -e '--build' > /dev/null || echo "$cmakeFlags")
+
+"$(dirname "$0")"/nix-run.sh cmake ${FLAGS:+"$FLAGS"} "$@"

--- a/.nix/nix-run.sh
+++ b/.nix/nix-run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+# support arbitrary commands trough symlinks to this file
+# e.g. create a symlink "make" to "nix-run.sh" and execution
+# of the symlink will run "make" in the nix-shell environment
+if [ "$(basename "$0")" != "nix-run.sh" ]; then
+  CMD="$(basename "$0")"
+fi
+
+# we need to check, if we're already running inside the
+# nix-shell environment, as some nix-run.sh symlinks may
+# call other nix-run.sh symlinks, which wouldn't work.
+# this is because nix-shell itself will not be available
+# when run in --pure mode
+if [ -n "$IN_NIX_RUN" ]; then
+  exec "$CMD" "$@"
+else
+  #relative path containing default.nix / shell.nix
+  PROJECT_DIR=$(dirname "$0")/..
+  QUOT_ARGS=$(printf '"%s" ' "$@")
+  IN_NIX_RUN=1 nix develop --command sh -c "$CMD $QUOT_ARGS" "$PROJECT_DIR"
+  exit $?
+fi

--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
-# Whisperly — Truly Private Messenger  
-**Privacy is a right, not a privilege.**  
+# Whisperly — Truly Private Messenger
+**Privacy is a right, not a privilege.**
 
 ---
 
-### Why Whisperly?  
-We grew tired of the illusion of privacy. Most messengers require phone numbers, store metadata, or rely on centralized servers that can be compromised (yes, even Signal). **Whisperly** is the answer. No accounts, no tracking, no compromises. Just you, your contact, and encryption you can trust.  
+### Why Whisperly?
+We grew tired of the illusion of privacy. Most messengers require phone numbers, store metadata, or rely on centralized servers that can be compromised (yes, even Signal). **Whisperly** is the answer. No accounts, no tracking, no compromises. Just you, your contact, and encryption you can trust.
 
-This project was born for personal use, but if it helps others too, we’ll be glad.  
+This project was born for personal use, but if it helps others too, we’ll be glad.
 
 ---
 
-### Core Principles  
-**Privacy by Design**  
-- **No Phone Numbers or Tracking**: Unique cryptographic keys replace phone numbers.  
-- **Zero Metadata Leaks**: Servers act as dumb relays — they don’t know who’s communicating or what’s being sent.  
-- **Forward Secrecy**: Session keys are ephemeral and destroyed after use.  
+### Core Principles
+**Privacy by Design**
+- **No Phone Numbers or Tracking**: Unique cryptographic keys replace phone numbers.
+- **Zero Metadata Leaks**: Servers act as dumb relays — they don’t know who’s communicating or what’s being sent.
+- **Forward Secrecy**: Session keys are ephemeral and destroyed after use.
 
-**Security First**  
-- **TLS 1.3 + End-to-End Encryption**: Protocol-level encryption with no "custom" implementations.  
-- **Anti-Feature Philosophy**: No cloud backups, third-party integrations, or convenience trade-offs.  
+**Security First**
+- **TLS 1.3 + End-to-End Encryption**: Protocol-level encryption with no "custom" implementations.
+- **Anti-Feature Philosophy**: No cloud backups, third-party integrations, or convenience trade-offs.
 
-**Simplicity & Transparency**  
-- **Minimalist Design**: Chat without distractions — no ads, bloat, or feature creep.  
-- **Fully Open Source**: Audit every line of code. No hidden backdoors.  
+**Simplicity & Transparency**
+- **Minimalist Design**: Chat without distractions — no ads, bloat, or feature creep.
+- **Fully Open Source**: Audit every line of code. No hidden backdoors.
 
 ---
 
@@ -31,25 +31,48 @@ This project was born for personal use, but if it helps others too, we’ll be g
 
 ---
 
-### Installation (Coming Soon)  
-While we prepare the release, you can:  
-1. Clone the repository:  
+### Installation (Coming Soon)
+While we prepare the release, you can:
+1. Clone the repository:
    ```bash  
-   git clone https://github.com/lnewtium/whispernet.git  
+   git clone https://github.com/lnewtium/whispernet.git 
 2. Follow updates in the dev branch.
 3. Want to help? See the Contributing section below.
 
 ---
 
-### Contributing  
-We believe in open source as a philosophy. Your contributions matter:  
-- Found a bug? Open an issue.  
-- Have an idea? Discuss it in Discussions.  
-- Pull requests are welcome!  
+### Contributing
+We believe in open source as a philosophy. Your contributions matter:
+- Found a bug? Open an issue.
+- Have an idea? Discuss it in Discussions.
+- Pull requests are welcome!
 
-**Guidelines**:  
-- Keep code simple and readable.   
-- No unnecessary dependencies.  
+**Guidelines**:
+- Keep code simple and readable.
+- No unnecessary dependencies.
+
+<details>
+<summary><strong>Development with CLion</strong></summary>
+
+1. **Create New Toolchain**
+   1. **Open:** `File → Settings → Build, Execution, Deployment → Toolchains`
+   2. **Add Toolchain:** Click `+` → `New Toolchain` → `System`
+   3. **Configure fields:**
+
+   | **CMake**      | `$PROJECT_DIR$/.nix/nix-cmake.sh`      |
+   |----------------|----------------------------------------|
+   | **C Compiler** | `$PROJECT_DIR$/.nix/gcc`               |
+   | **C++ Compiler**| `$PROJECT_DIR$/.nix/g++`               |
+   | **Build Tool** | `$PROJECT_DIR$/.nix/make`              |
+
+2. **Configure CMake Profile**
+
+   1. **Go to:** `File → Settings → Build, Execution, Deployment → CMake`
+   2. Select the **toolchain** you created
+
+
+3. **Try To Build**
+</details>
 
 ---
 


### PR DESCRIPTION
## Changes Overview  

### 1. **Nix Environment Integration for CLion**  
**Added:**  
- **Wrapper Scripts** (`nix-cmake.sh`, `nix-run.sh`):  
  Execute build commands (e.g., CMake, `make`) **within the Nix environment**, ensuring all tools and dependencies are sourced from the project’s Nix configuration.  
- **Symlinks** (`gcc`, `g++`, `make`):  
  Act as proxies to invoke **Nix-provided compilers and tools** instead of system-wide versions.  

**How It Works:**  
1. When CLion triggers a build, it uses the symlinks (e.g., `.nix/gcc`).  
2. Symlinks call the wrapper scripts, which launch the Nix shell.  
3. The Nix shell provides the exact compiler/tool versions defined in the project. 

### 2. **Updated Documentation**  
**Added to README:**  
- A step-by-step guide **"Development with CLion"**


`Screenshot:`


![Screenshot 2025-05-16 020459](https://github.com/user-attachments/assets/60d26f2a-fcd7-4350-8b47-e3db1b09efc8)